### PR TITLE
feature: Remove ability to accept natural / terrain sourced filth

### DIFF
--- a/Defs/TerrainDefs/path.xml
+++ b/Defs/TerrainDefs/path.xml
@@ -10,6 +10,9 @@
 		<edgeType>FadeRough</edgeType>
 		<renderPrecedence>350</renderPrecedence>
 		<terrainAffordanceNeeded>GrowSoil</terrainAffordanceNeeded>
+		<filthAcceptanceMask><!-- FloorBase defaults to all -->
+			<li>Unnatural</li>
+		</filthAcceptanceMask>
 		<takeFootprints>true</takeFootprints>
 		<statBases>
 			<Beauty>0</Beauty>


### PR DESCRIPTION
Tested on r1.1 - this patch may not work on r1.0.  I don't know when this new 'mask' was implemented.